### PR TITLE
Suggestion for type inference for the Model

### DIFF
--- a/src/main/java/org/codebrewery/ApiInterface.java
+++ b/src/main/java/org/codebrewery/ApiInterface.java
@@ -5,18 +5,18 @@ import java.util.List;
 /**
  * Created by ejeserl on 9/19/15.
  */
-public interface ApiInterface<T> {
+public interface ApiInterface {
 
-    Model save(Model model) throws JavaOrmenException;
+    <M extends Model> M save(M model) throws JavaOrmenException;
 
-    Model update(Model model) throws JavaOrmenException;
+    <M extends Model> M update(M model) throws JavaOrmenException;
 
-    Model insert(Model model) throws JavaOrmenException;
+    <M extends Model> M insert(M model) throws JavaOrmenException;
 
-    void delete(Model model) throws JavaOrmenException;
+    <M extends Model> void delete(M model) throws JavaOrmenException;
 
-    Model fetch(Model model) throws JavaOrmenException;
+    <M extends Model> M fetch(M model) throws JavaOrmenException;
 
-    List<Model> getAll(Class<? extends Model> aClass) throws JavaOrmenException;
+    <M extends Model> List<M> getAll(Class<M> aClass) throws JavaOrmenException;
 
 }

--- a/src/main/java/org/codebrewery/DefaultApiImplementation.java
+++ b/src/main/java/org/codebrewery/DefaultApiImplementation.java
@@ -1,17 +1,16 @@
 package org.codebrewery;
 
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Response;
-
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.Response;
 
 /**
  * Created by ejeserl on 9/19/15.
  *
- *19520622-1482
+ * 19520622-1482
  */
 public class DefaultApiImplementation implements ApiInterface {
 
@@ -28,25 +27,26 @@ public class DefaultApiImplementation implements ApiInterface {
 
     String generateCompleteBaseUrl() {
 
-        return "http://"+config.getHost()  + ":" + config.getPort() + "/" + config.getApiLocation() + "/";
+        return "http://" + config.getHost() + ":" + config.getPort() + "/" + config.getApiLocation() + "/";
     }
 
     String generateInstanceUrl(Model model) {
         return generateCollectionUrl(model.getClass()) + "/" + model.getIdentifierValue();
     }
+
     @Override
-    public Model save(Model model) throws JavaOrmenException {
+    public <T extends Model> T save(T model) throws JavaOrmenException {
         try {
 
-            String url =  generateCollectionUrl(model.getClass());
+            String url = generateCollectionUrl(model.getClass());
             // execute the query
             Response response = execute(new AsyncHttpClient().prepareGet(url));
             // convert the response to an Model
-            return JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
+            return (T) JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
 
-        } catch (InterruptedException  | ExecutionException | IOException e) {
+        } catch (InterruptedException | ExecutionException | IOException e) {
             // wrap the exception in a javaOrmenException
-           throw new JavaOrmenException("failed to save model with identifier" + model.getIdentifierValue(),e);
+            throw new JavaOrmenException("failed to save model with identifier" + model.getIdentifierValue(), e);
         }
     }
 
@@ -68,40 +68,40 @@ public class DefaultApiImplementation implements ApiInterface {
     }
 
     @Override
-    public Model update(Model model) throws JavaOrmenException {
+    public <T extends Model> T update(T model) throws JavaOrmenException {
         try {
 
             String url = generateInstanceUrl(model);
             // execute the query
             Response response = execute(new AsyncHttpClient().preparePut(url).setBody(JSONConverter.marshall(model)));
             // convert the response to an Model
-            return JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
+            return (T) JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
 
-        } catch (InterruptedException  | ExecutionException | IOException e) {
+        } catch (InterruptedException | ExecutionException | IOException e) {
             // wrap the exception in a javaOrmenException
-            throw new JavaOrmenException("failed to update model with identifier " + model.getIdentifierValue(),e);
+            throw new JavaOrmenException("failed to update model with identifier " + model.getIdentifierValue(), e);
         }
     }
 
     @Override
-    public Model insert(Model model) throws JavaOrmenException {
+    public <T extends Model> T insert(T model) throws JavaOrmenException {
 
-            try {
+        try {
 
-                String url = generateInstanceUrl(model);
-                // execute the query
-                Response response = execute(new AsyncHttpClient().preparePost(url).setBody(JSONConverter.marshall(model)));
-                // convert the response to an Model
-                return JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
+            String url = generateInstanceUrl(model);
+            // execute the query
+            Response response = execute(new AsyncHttpClient().preparePost(url).setBody(JSONConverter.marshall(model)));
+            // convert the response to an Model
+            return (T) JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
 
-            } catch (InterruptedException  | ExecutionException | IOException e) {
-                // wrap the exception in a javaOrmenException
-                throw new JavaOrmenException("failed to insert model with identifier " + model.getIdentifierValue(),e);
-            }
+        } catch (InterruptedException | ExecutionException | IOException e) {
+            // wrap the exception in a javaOrmenException
+            throw new JavaOrmenException("failed to insert model with identifier " + model.getIdentifierValue(), e);
+        }
     }
 
     @Override
-    public void delete(Model model) throws JavaOrmenException {
+    public <T extends Model> void delete(T model) throws JavaOrmenException {
         try {
 
             String url = generateInstanceUrl(model);
@@ -109,30 +109,30 @@ public class DefaultApiImplementation implements ApiInterface {
             Response response = execute(new AsyncHttpClient().prepareDelete(url));
             // convert the response to an Model
 
-        } catch (InterruptedException  | ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
             // wrap the exception in a javaOrmenException
-            throw new JavaOrmenException("failed to delete model with identifier " + model.getIdentifierValue(),e);
+            throw new JavaOrmenException("failed to delete model with identifier " + model.getIdentifierValue(), e);
         }
     }
 
     @Override
-    public Model fetch(Model model) throws JavaOrmenException {
+    public <T extends Model> T fetch(T model) throws JavaOrmenException {
         try {
 
             String url = generateInstanceUrl(model);
             // execute the query
             Response response = execute(new AsyncHttpClient().prepareGet(url));
             // convert the response to an Model
-            return JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
+            return (T) JSONConverter.unMarshall(response.getResponseBody(), model.getClass());
 
-        } catch (InterruptedException  | ExecutionException | IOException e) {
+        } catch (InterruptedException | ExecutionException | IOException e) {
             // wrap the exception in a javaOrmenException
-            throw new JavaOrmenException("failed to fetch model with identifier " + model.getIdentifierValue(),e);
+            throw new JavaOrmenException("failed to fetch model with identifier " + model.getIdentifierValue(), e);
         }
     }
 
     @Override
-    public List<Model> getAll(Class aClass) throws JavaOrmenException {
+    public <M extends Model> List<M> getAll(Class<M> aClass) throws JavaOrmenException {
         try {
 
             String url = generateCollectionUrl(aClass);
@@ -141,11 +141,10 @@ public class DefaultApiImplementation implements ApiInterface {
             // convert the response to an Model
             return JSONConverter.unMarshallList(response.getResponseBody(), aClass);
 
-        } catch (InterruptedException  | ExecutionException | IOException e) {
+        } catch (InterruptedException | ExecutionException | IOException e) {
             // wrap the exception in a javaOrmenException
-            throw new JavaOrmenException("failed to fech list of models of class " + aClass.getSimpleName(),e);
+            throw new JavaOrmenException("failed to fech list of models of class " + aClass.getSimpleName(), e);
         }
     }
-
 
 }

--- a/src/main/java/org/codebrewery/JSONConverter.java
+++ b/src/main/java/org/codebrewery/JSONConverter.java
@@ -1,9 +1,9 @@
 package org.codebrewery;
 
-import org.codehaus.jackson.map.ObjectMapper;
-
 import java.io.IOException;
 import java.util.List;
+
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Created by jepp3 on 2015-09-06.
@@ -18,35 +18,34 @@ public class JSONConverter {
     /**
      * Converts a AbstractRestModel to a json string. It will look at the anotations on the elements.
      *
-     * @param restModel the model that should be marshalled
+     * @param restModel
+     *            the model that should be marshalled
      * @return
      * @throws IOException
      */
     public static String marshall(Model restModel) throws IOException {
-
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(restModel);
     }
 
     /**
-     *  Converts an json String into a object of the specific class type.
-     * @param json json string
-     * @param klazz the AbstractRestModel class to be used
+     * Converts an json String into a object of the specific class type.
+     * 
+     * @param json
+     *            json string
+     * @param klazz
+     *            the AbstractRestModel class to be used
      * @return
      * @throws IOException
      */
-    public static Model unMarshall(String json, Class<? extends Model> klazz) throws IOException {
-
+    public static <T extends Model> T unMarshall(String json, Class<T> klazz) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(json, klazz);
     }
 
-    public static List<Model> unMarshallList(String json, Class<? extends Model> klazz) throws IOException {
-
+    public static <T extends Model> List<T> unMarshallList(String json, Class<T> klazz) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, klazz));
     }
-
-
 
 }

--- a/src/main/java/org/codebrewery/JavaOrmenException.java
+++ b/src/main/java/org/codebrewery/JavaOrmenException.java
@@ -4,6 +4,7 @@ package org.codebrewery;
  * Created by ejeserl on 9/19/15.
  */
 public class JavaOrmenException extends Exception {
+    private static final long serialVersionUID = -2687061472385947476L;
     public JavaOrmenException() { super(); }
     public JavaOrmenException(String message) { super(message); }
     public JavaOrmenException(String message, Throwable cause) { super(message, cause); }

--- a/src/main/java/org/codebrewery/Model.java
+++ b/src/main/java/org/codebrewery/Model.java
@@ -2,27 +2,23 @@ package org.codebrewery;
 
 import java.util.List;
 
-
-
 public abstract class Model {
 
     public static ApiInterface api() {
         return ApiFactory.getDefaultImplementation();
     }
 
-
     public abstract String getIdentifierValue();
-
 
     /**
      * Return a named ApiInterface that is typically different to the default apiImpl.
      *
      * <p>
-     * If you are using multiple restApis then each api has a name and maps to a single
-     * ApiInterface. You can use this method to get an ApiInterface for another restApi.
+     * If you are using multiple restApis then each api has a name and maps to a single ApiInterface. You can use this method to get an ApiInterface for another
+     * restApi.
      *
      * @param apiImpl
-     *          The name of the ApiInterface. If this is null then the default ApiInterface is returned.
+     *            The name of the ApiInterface. If this is null then the default ApiInterface is returned.
      */
     public static ApiInterface api(String apiImpl) {
         return null;
@@ -32,24 +28,25 @@ public abstract class Model {
      * Insert or update this model depending on its state.
      *
      * <p>
-     * ApiFactory will detect if this is a new model or a previously fetched model and perform either an
-     * insert or an update based on that.
+     * ApiFactory will detect if this is a new model or a previously fetched model and perform either an insert or an update based on that.
      *
      * You may see this as an smart method for update/insert.
+     * 
      * @see ApiInterface#save(Model)
      */
-    public Model save() throws JavaOrmenException {
-        return api().save(this);
+    @SuppressWarnings("unchecked")
+    public <T extends Model> T save() throws JavaOrmenException {
+        return api().save((T) this);
     }
-
 
     /**
      * Update this model.
      *
      * @see ApiInterface#update(Model)
      */
-    public Model update() throws JavaOrmenException{
-        return api().update(this);
+    @SuppressWarnings("unchecked")
+    public <T extends Model> T update() throws JavaOrmenException {
+        return api().update((T) this);
     }
 
     /**
@@ -57,8 +54,9 @@ public abstract class Model {
      *
      * @see ApiInterface#insert(Model)
      */
-    public Model insert() throws JavaOrmenException {
-        return api().insert(this);
+    @SuppressWarnings("unchecked")
+    public <T extends Model> T insert() throws JavaOrmenException {
+        return api().insert((T) this);
     }
 
     /**
@@ -70,61 +68,63 @@ public abstract class Model {
         api().delete(this);
     }
 
-
     /**
      * Refreshes this model from the API.
      *
      * @see ApiInterface#fetch(Model)
      */
-    public Model fetch() throws JavaOrmenException {
-        return api().fetch(this);
+    @SuppressWarnings("unchecked")
+    public <T extends Model> T fetch() throws JavaOrmenException {
+        return api().fetch((T) this);
     }
 
     /**
      * A concrete implementation of Find.
-     * <p>.
+     * <p>
+     * .
      * </p>
      */
-    public static class Finder  {
+    public static class Finder<T extends Model> {
 
-        private final Class<? extends Model> type;
-
+        private final Class<T> type;
 
         /**
          * Create with the type of the model model.
          *
-         * <pre>{@code
-         *
+         * <pre>
+         * {@code
+         * 
          * public class Customer extends BaseModel {
-         *
+         * 
          *   public static final Finder<Long,Customer> find = new Finder<Long,Customer>(Customer.class);
          *   ...
-         *
-         * }</pre>
+         * 
+         * }
+         * </pre>
          *
          * <p/>
-         * The preferred approach is to instead use <code>Find</code> as below. This approach is more DRY in that it does
-         * not require the class literal Customer.class to be passed into the constructor.
+         * The preferred approach is to instead use <code>Find</code> as below. This approach is more DRY in that it does not require the class literal
+         * Customer.class to be passed into the constructor.
          *
-         * <pre>{@code
-         *
+         * <pre>
+         * {@code
+         * 
          * public class Customer extends BaseModel {
-         *
+         * 
          *   public static final Find<Long,Customer> find = new Find<Long,Customer>(){};
          *   ...
-         *
-         * }</pre>
+         * 
+         * }
+         * </pre>
          */
 
-        public Finder( Class<? extends Model> type) {
-
+        public Finder(Class<T> type) {
             this.type = type;
         }
 
-        public List<Model> all() throws JavaOrmenException {
+        public List<T> all() throws JavaOrmenException {
             return api().getAll(this.type);
         }
     }
-
 
 }

--- a/src/main/java/org/codebrewery/ModelHelper.java
+++ b/src/main/java/org/codebrewery/ModelHelper.java
@@ -1,7 +1,6 @@
 package org.codebrewery;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 
 /**
  * Created by ejeserl on 9/19/15.

--- a/src/test/java/org/codebrewery/DogModel.java
+++ b/src/test/java/org/codebrewery/DogModel.java
@@ -1,13 +1,5 @@
 package org.codebrewery;
 
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.ListenableFuture;
-import com.ning.http.client.Response;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Created by ejeserl on 9/19/15.
@@ -19,14 +11,13 @@ public class DogModel extends Model {
 
     private int age;
 
-
     public DogModel(String name, int age) {
         this.name = name;
         this.age = age;
     }
 
     DogModel() {
-        this.name ="";
+        this.name = "";
         this.age = 0;
     }
 
@@ -51,5 +42,5 @@ public class DogModel extends Model {
         this.name = name;
     }
 
-    public static final Finder find = new Finder(DogModel.class);
+    public static final Finder<DogModel> find = new Finder<>(DogModel.class);
 }

--- a/src/test/java/org/codebrewery/MockDefaultApiImplementation.java
+++ b/src/test/java/org/codebrewery/MockDefaultApiImplementation.java
@@ -1,5 +1,11 @@
 package org.codebrewery;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.Request;
@@ -7,36 +13,26 @@ import com.ning.http.client.Response;
 import com.ning.http.client.cookie.Cookie;
 import com.ning.http.client.uri.Uri;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Scanner;
-import java.util.concurrent.ExecutionException;
-
 /**
  * Created by ejeserl on 9/19/15.
  */
-public class MockDefaultApiImplementation extends DefaultApiImplementation{
+public class MockDefaultApiImplementation extends DefaultApiImplementation {
 
     private Request latest;
     private final String dataToEcho;
     private ExecutionException exception;
 
-    MockDefaultApiImplementation(ApiConfig config,String name) {
+    MockDefaultApiImplementation(ApiConfig config, String name) {
         super(config);
 
-        this.dataToEcho =  convertStreamToString(this.getClass().getResourceAsStream(name));
+        this.dataToEcho = convertStreamToString(this.getClass().getResourceAsStream(name));
 
     }
 
-    MockDefaultApiImplementation(ApiConfig config,ExecutionException exception) {
+    MockDefaultApiImplementation(ApiConfig config, ExecutionException exception) {
         super(config);
         dataToEcho = "";
-        this.exception= exception;
+        this.exception = exception;
     }
 
     static String convertStreamToString(java.io.InputStream is) {
@@ -44,14 +40,14 @@ public class MockDefaultApiImplementation extends DefaultApiImplementation{
         return s.hasNext() ? s.next() : "";
     }
 
-
     public Request getLatestExecutedRequestBuilder() {
         return latest;
     }
+
     @Override
     Response execute(AsyncHttpClient.BoundRequestBuilder boundRequestBuilder) throws ExecutionException, InterruptedException {
 
-        if(this.exception != null) {
+        if (this.exception != null) {
             throw this.exception;
         }
 
@@ -154,6 +150,5 @@ public class MockDefaultApiImplementation extends DefaultApiImplementation{
         };
 
     }
-
 
 }

--- a/src/test/java/org/codebrewery/TestDefaultApiImplementation.java
+++ b/src/test/java/org/codebrewery/TestDefaultApiImplementation.java
@@ -18,7 +18,7 @@ public class TestDefaultApiImplementation {
         MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
-        DogModel savedModel = (DogModel) mockImpl.save(mockModel);
+        DogModel savedModel = mockImpl.save(mockModel);
 
         // assert
         assertEquals("pluto", savedModel.getName());
@@ -50,7 +50,7 @@ public class TestDefaultApiImplementation {
         MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
-        DogModel savedModel = (DogModel) mockImpl.fetch(mockModel);
+        DogModel savedModel = mockImpl.fetch(mockModel);
 
         // assert
         assertEquals("pluto", savedModel.getName());
@@ -68,7 +68,7 @@ public class TestDefaultApiImplementation {
         MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
-        DogModel savedModel = (DogModel) mockImpl.update(mockModel);
+        DogModel savedModel = mockImpl.update(mockModel);
 
         // assert
         assertEquals("pluto", savedModel.getName());

--- a/src/test/java/org/codebrewery/TestDefaultApiImplementation.java
+++ b/src/test/java/org/codebrewery/TestDefaultApiImplementation.java
@@ -1,14 +1,13 @@
 package org.codebrewery;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
  * Created by ejeserl on 9/19/15.
  */
 public class TestDefaultApiImplementation {
-
 
     @Test
     public void test_that_its_possible_to_save_an_model() throws Exception {
@@ -16,7 +15,7 @@ public class TestDefaultApiImplementation {
         // prepare
         DogModel mockModel = new DogModel("pluto", 5);
         ApiConfig apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
-        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig,"plainPluto.json");
+        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
         DogModel savedModel = (DogModel) mockImpl.save(mockModel);
@@ -31,19 +30,16 @@ public class TestDefaultApiImplementation {
     public void test_that_its_possible_to_delete_the_model() throws Exception {
 
         // prepare
-        DogModel mockModel = new DogModel("pluto",5);
+        DogModel mockModel = new DogModel("pluto", 5);
         ApiConfig apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
-        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig,"plainPluto.json");
-
+        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
         mockImpl.delete(mockModel);
 
         assertEquals("http://localhost:8081/api/dogs/pluto", mockImpl.getLatestExecutedRequestBuilder().getUrl());
 
-
     }
-
 
     @Test
     public void test_that_its_possible_to_fetch_an_model() throws Exception {
@@ -51,8 +47,7 @@ public class TestDefaultApiImplementation {
         // prepare
         DogModel mockModel = new DogModel("pluto", 5);
         ApiConfig apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
-        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig,"plainPluto.json");
-
+        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
         DogModel savedModel = (DogModel) mockImpl.fetch(mockModel);
@@ -68,16 +63,16 @@ public class TestDefaultApiImplementation {
     public void test_that_its_possible_to_update_an_model() throws Exception {
 
         // prepare
-        DogModel mockModel = new DogModel("pluto",5);
+        DogModel mockModel = new DogModel("pluto", 5);
         ApiConfig apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
-        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig,"plainPluto.json");
+        MockDefaultApiImplementation mockImpl = new MockDefaultApiImplementation(apiConfig, "plainPluto.json");
 
         // execute
-        DogModel savedModel = (DogModel)  mockImpl.update(mockModel);
+        DogModel savedModel = (DogModel) mockImpl.update(mockModel);
 
         // assert
-        assertEquals("pluto",savedModel.getName());
-        assertEquals(3,savedModel.getAge());
+        assertEquals("pluto", savedModel.getName());
+        assertEquals(3, savedModel.getAge());
         assertEquals("http://localhost:8081/api/dogs/pluto", mockImpl.getLatestExecutedRequestBuilder().getUrl());
 
     }

--- a/src/test/java/org/codebrewery/TestModel.java
+++ b/src/test/java/org/codebrewery/TestModel.java
@@ -1,19 +1,16 @@
 package org.codebrewery;
 
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.util.List;
-
-import static org.easymock.EasyMock.expect;
-
-import static org.junit.Assert.assertEquals;
-import static org.powermock.api.easymock.PowerMock.*;
-
-
 
 /**
  * Created by ejeserl on 9/20/15.
@@ -23,32 +20,34 @@ import static org.powermock.api.easymock.PowerMock.*;
 @PrepareForTest(ApiFactory.class)
 public class TestModel {
 
-
     private ApiConfig apiConfig;
     private MockDefaultApiImplementation mockApiImpl;
+
     /**
      * All these tests will use powermock.
      *
      */
     public void setUpWithMock() {
 
-        setUpWithMock("plainPluto.json",null);
+        setUpWithMock("plainPluto.json", null);
 
     }
 
     public void setUpWithMock(String fileName) {
-        setUpWithMock(fileName,null);
+        setUpWithMock(fileName, null);
     }
+
     public void setUpWithMock(Exception exception) {
-        setUpWithMock(null,exception);
+        setUpWithMock(null, exception);
     }
-    public void setUpWithMock(String fileName,Exception e) {
+
+    public void setUpWithMock(String fileName, Exception e) {
         // 1. create config
         // 2. create mock
         // 3. init mock
 
         apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
-        mockApiImpl = new MockDefaultApiImplementation(apiConfig,fileName);
+        mockApiImpl = new MockDefaultApiImplementation(apiConfig, fileName);
         // We create a new instance of test class under test as usually.
 
         // This is the way to tell PowerMock to mock all static methods of a
@@ -62,29 +61,25 @@ public class TestModel {
 
     }
 
-
-
     @Test
     public void save_model() throws JavaOrmenException {
         setUpWithMock();
         Model model = new DogModel();
 
-        DogModel  changedModel  = (DogModel) model.save();
+        DogModel changedModel = (DogModel) model.save();
 
         // Note how we verify the class, not the instance!
         PowerMock.verifyAll();
         // Assert that the ID is correct
         assertEquals("pluto", changedModel.getName());
-        assertEquals("http://localhost:8081/api/dogs",mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
+        assertEquals("http://localhost:8081/api/dogs", mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
 
     }
-
-
 
     @Test
     public void delete_model() throws JavaOrmenException {
         setUpWithMock();
-        Model model = new DogModel("pluto",123);
+        Model model = new DogModel("pluto", 123);
 
         model.delete();
 
@@ -92,29 +87,27 @@ public class TestModel {
         PowerMock.verifyAll();
 
         // Assert that the ID is correct
-        assertEquals("http://localhost:8081/api/dogs/pluto",mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
+        assertEquals("http://localhost:8081/api/dogs/pluto", mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
     }
-
-
 
     @Test
     public void fetch_model() throws JavaOrmenException {
         setUpWithMock();
-        DogModel model = new DogModel("plutoXII",4);
+        DogModel model = new DogModel("plutoXII", 4);
 
-        DogModel  changedModel  = (DogModel) model.fetch();
+        DogModel changedModel = (DogModel) model.fetch();
 
         // Note how we verify the class, not the instance!
         PowerMock.verifyAll();
 
         // Assert that the ID is correct
         assertEquals("pluto", changedModel.getName());
-        assertEquals("http://localhost:8081/api/dogs/plutoXII",mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
+        assertEquals("http://localhost:8081/api/dogs/plutoXII", mockApiImpl.getLatestExecutedRequestBuilder().getUrl());
 
         // verify that the returned model has an different name.
-        assertEquals("pluto",changedModel.getName());
+        assertEquals("pluto", changedModel.getName());
         // verify that the old model still got the old name
-        assertEquals("plutoXII",model.getName());
+        assertEquals("plutoXII", model.getName());
 
     }
 
@@ -122,9 +115,9 @@ public class TestModel {
     public void update_model() throws JavaOrmenException {
 
         setUpWithMock();
-        Model model = new DogModel("plutoXII",1234);
+        Model model = new DogModel("plutoXII", 1234);
 
-        DogModel  changedModel  = (DogModel) model.update();
+        DogModel changedModel = model.update();
 
         // Note how we verify the class, not the instance!
         PowerMock.verifyAll();
@@ -137,14 +130,14 @@ public class TestModel {
 
         setUpWithMock("twoPlutosInAList.json");
 
-        List<Model> listOfDogs = DogModel.find.all();
+        List<DogModel> listOfDogs = DogModel.find.all();
 
         // Note how we verify the class, not the instance!
         PowerMock.verifyAll();
 
         // Assert that the ID is correct
-        assertEquals(1,listOfDogs.size());
-        assertEquals("pluto",listOfDogs.get(0).getIdentifierValue());
+        assertEquals(1, listOfDogs.size());
+        assertEquals("pluto", listOfDogs.get(0).getIdentifierValue());
 
     }
 }

--- a/src/test/java/org/codebrewery/TestModelNegative.java
+++ b/src/test/java/org/codebrewery/TestModelNegative.java
@@ -1,21 +1,17 @@
 package org.codebrewery;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static org.easymock.EasyMock.expect;
-
-import static org.junit.Assert.assertEquals;
-import static org.powermock.api.easymock.PowerMock.*;
-
-
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Created by ejeserl on 9/20/15.
@@ -25,33 +21,35 @@ import static org.powermock.api.easymock.PowerMock.*;
 @PrepareForTest(ApiFactory.class)
 public class TestModelNegative {
 
-
     private ApiConfig apiConfig;
     private MockDefaultApiImplementation mockApiImpl;
+
     /**
      * All these tests will use powermock.
      *
      */
     public void setUpWithMock() {
 
-        setUpWithMock("plainPluto.json",null);
+        setUpWithMock("plainPluto.json", null);
 
     }
 
     public void setUpWithMock(String fileName) {
-        setUpWithMock(fileName,null);
+        setUpWithMock(fileName, null);
     }
+
     public void setUpWithMock(ExecutionException exception) {
         setUpWithMock(null, exception);
     }
-    public void setUpWithMock(String fileName,ExecutionException e) {
+
+    public void setUpWithMock(String fileName, ExecutionException e) {
         // 1. create config
         // 2. create mock
         // 3. init mock
 
         apiConfig = new ApiConfig.ConfigBuilder().apiLocation("api").port("8081").host("localhost").build();
 
-        if(e != null) {
+        if (e != null) {
             mockApiImpl = new MockDefaultApiImplementation(apiConfig, e);
         } else {
             mockApiImpl = new MockDefaultApiImplementation(apiConfig, fileName);
@@ -68,47 +66,40 @@ public class TestModelNegative {
 
     }
 
-
-
     @Test(expected = JavaOrmenException.class)
     public void save_model() throws JavaOrmenException {
-        setUpWithMock(new ExecutionException("BOM",new IOException("failed to save the model")));
-        Model model = new DogModel();
+        setUpWithMock(new ExecutionException("BOM", new IOException("failed to save the model")));
+        DogModel model = new DogModel();
 
-        DogModel  changedModel  = (DogModel) model.save();
-
+        DogModel changedModel = model.save();
 
     }
-
-
 
     @Test(expected = JavaOrmenException.class)
     public void delete_model() throws JavaOrmenException {
         setUpWithMock(new ExecutionException("BOM", new IOException("failed to save the model")));
-        Model model = new DogModel("pluto",123);
+        Model model = new DogModel("pluto", 123);
 
         model.delete();
 
     }
 
-
-
     @Test(expected = JavaOrmenException.class)
     public void fetch_model() throws JavaOrmenException {
-        setUpWithMock(new ExecutionException("BOM",new IOException("failed to save the model")));
-        DogModel model = new DogModel("plutoXII",4);
+        setUpWithMock(new ExecutionException("BOM", new IOException("failed to save the model")));
+        DogModel model = new DogModel("plutoXII", 4);
 
-        DogModel  changedModel  = (DogModel) model.fetch();
+        DogModel changedModel = model.fetch();
 
     }
 
     @Test(expected = JavaOrmenException.class)
     public void update_model() throws JavaOrmenException {
 
-        setUpWithMock(new ExecutionException("BOM",new IOException("failed to save the model")));
-        Model model = new DogModel("plutoXII",1234);
+        setUpWithMock(new ExecutionException("BOM", new IOException("failed to save the model")));
+        DogModel model = new DogModel("plutoXII", 1234);
 
-        DogModel  changedModel  = (DogModel) model.update();
+        DogModel changedModel = model.update();
 
     }
 
@@ -117,9 +108,7 @@ public class TestModelNegative {
 
         setUpWithMock(new ExecutionException("BOM", new IOException("failed to save the model")));
 
-        List<Model> listOfDogs = DogModel.find.all();
-
-
+        List<DogModel> listOfDogs = DogModel.find.all();
 
     }
 }


### PR DESCRIPTION
Suggestion for type inference for the Model

This PR is a suggestion to fix automated type inference allowing the user to write code without casting Model instances.  
The type of the Model to be returned is inferred by the left side of the expression.

Example provided below

``` java
DogModel mockModel = new DogModel("pluto", 5);
DogModel savedModel = mockImpl.fetch(mockModel);
```
